### PR TITLE
Ignore module-info in enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,8 @@
 										<ignoreClasses>
 											<!-- ignore multirelease JAR classes -->
 											<ignoreClass>META-INF/versions/**/*</ignoreClass>
+											<!-- ignore JAVA 9 module-info files, for eg org.ow2.asm:asm:6.0+ -->
+											<ignoreClass>module-info</ignoreClass>
 										</ignoreClasses>
 									</enforceBytecodeVersion>
 								</rules>


### PR DESCRIPTION
Java 8 won't load the `module-info.class`, so it can be safely ignored by the enforcer plugin.

Without it `org.ow2.asm:asm:6.0` will trip the enforcer plugin.